### PR TITLE
Fix typo in README: correct GitHub profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://readme-typing-svg.herokuapp.com?font=Fira+Code&weight=500&size=20&duration=4000&pause=2000&color=0366D6&center=true&vCenter=true&random=false&width=600&lines=Life+isn%27t+about+waiting+for+the+storm+to+pass;It%27s+about+learning+to+dance+in+the+rain" alt="Typing SVG" />
 
 <p>
-    <a href="https://github.com/KevinZh0A"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
+    <a href="https://github.com/Kevinzh0C"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
     <a href="mailto:kaiqiz07@gmail.com"><img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Gmail"></a>
   </p>
 </div>


### PR DESCRIPTION
# Fix typo in README: correct GitHub profile link

## Summary
Corrects the GitHub profile badge link in `README.md` from `KevinZh0A` (incorrect) to `Kevinzh0C` (the actual GitHub username matching the repo owner).

## Review & Testing Checklist for Human
- [ ] Verify that `Kevinzh0C` is the intended GitHub profile link (matches repo owner)
- [ ] Click the GitHub badge on the rendered README to confirm it navigates to the correct profile

### Notes
- Requested by: @Kevinzh0C
- [Link to Devin run](https://app.devin.ai/sessions/11d2fd739e6b4c36b0420ac2f87c21ac)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kevinzh0c/kevinzh0c/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
