### PR TITLE
Fix typo in GitHub profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://readme-typing-svg.herokuapp.com?font=Fira+Code&weight=500&size=20&duration=4000&pause=2000&color=0366D6&center=true&vCenter=true&random=false&width=600&lines=Life+isn%27t+about+waiting+for+the+storm+to+pass;It%27s+about+learning+to+dance+in+the+rain" alt="Typing SVG" />
 
 <p>
-    <a href="https://github.com/KevinZh0A"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
+    <a href="https://github.com/Kevinzh0C"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
     <a href="mailto:kaiqiz07@gmail.com"><img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Gmail"></a>
   </p>
 </div>


### PR DESCRIPTION
# Fix typo in GitHub profile link

## Summary
The GitHub badge in the README header linked to `https://github.com/KevinZh0A` instead of the correct profile `https://github.com/Kevinzh0C`. This one-character fix corrects the URL so the badge points to the actual profile.

## Review & Testing Checklist for Human
- [ ] Verify the corrected link (`https://github.com/Kevinzh0C`) resolves to the intended GitHub profile

### Notes
- Requested by: @Kevinzh0C
- [Link to Devin run](https://app.devin.ai/sessions/d63429d0e6d14d2a8e7117728a24d77d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kevinzh0c/kevinzh0c/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
