### PR TITLE
Fix GitHub profile link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://readme-typing-svg.herokuapp.com?font=Fira+Code&weight=500&size=20&duration=4000&pause=2000&color=0366D6&center=true&vCenter=true&random=false&width=600&lines=Life+isn%27t+about+waiting+for+the+storm+to+pass;It%27s+about+learning+to+dance+in+the+rain" alt="Typing SVG" />
 
 <p>
-    <a href="https://github.com/KevinZh0A"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
+    <a href="https://github.com/Kevinzh0C"><img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
     <a href="mailto:kaiqiz07@gmail.com"><img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Gmail"></a>
   </p>
 </div>


### PR DESCRIPTION
# Fix GitHub profile link typo in README.md

## Summary
Corrects the GitHub profile badge link from `https://github.com/KevinZh0A` (broken/wrong profile) to `https://github.com/Kevinzh0C` (correct profile).

## Review & Testing Checklist for Human
- [ ] Verify that `https://github.com/Kevinzh0C` resolves to the correct profile
- [ ] Confirm the README renders correctly on the GitHub profile page after merge

### Notes
Requested by: @Kevinzh0C
[Link to Devin run](https://app.devin.ai/sessions/286729050d9b46498273579e93527fb2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kevinzh0c/kevinzh0c/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
